### PR TITLE
Define the basis for a generic and customizable BalancerSdkConfig

### DIFF
--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -62,7 +62,7 @@
     "@graphql-codegen/typescript-resolvers": "2.4.1"
   },
   "dependencies": {
-    "@balancer-labs/sor": "^2.1.0-beta.4",
+    "@balancer-labs/sor": "github:beethovenxfi/balancer-sor#daniel/sor-refactor-merged",
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/abstract-signer": "^5.5.0",
     "@ethersproject/contracts": "^5.5.0",

--- a/balancer-js/src/constants/contracts.ts
+++ b/balancer-js/src/constants/contracts.ts
@@ -1,1 +1,74 @@
+import { Network } from './network';
+import { BalancerNetworkConfig } from '../types';
+
 export const balancerVault = '0xBA12222222228d8Ba445958a75a0704d566BF2C8';
+
+export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
+    [Network.MAINNET]: {
+        chainId: Network.MAINNET, //1
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+        multicall: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
+        staBal3Pool: {
+            id: '0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe',
+            address: '0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2',
+        },
+        subgraphUrl:
+            'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2',
+    },
+    [Network.ROPSTEN]: {
+        chainId: Network.ROPSTEN, //3
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+        multicall: '0x53c43764255c17bd724f74c4ef150724ac50a3ed',
+        subgraphUrl: '',
+    },
+    [Network.RINKEBY]: {
+        chainId: Network.RINKEBY, //4
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+        multicall: '0x42ad527de7d4e9d9d011ac45b31d8551f8fe9821',
+        subgraphUrl:
+            'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-rinkeby-v2',
+    },
+    [Network.GÖRLI]: {
+        chainId: Network.GÖRLI, //5
+        vault: '0x65748E8287Ce4B9E6D83EE853431958851550311',
+        weth: '0x9A1000D492d40bfccbc03f413A48F5B6516Ec0Fd',
+        multicall: '0x42ad527de7d4e9d9d011ac45b31d8551f8fe9821',
+        subgraphUrl:
+            'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2',
+    },
+    [Network.KOVAN]: {
+        chainId: Network.KOVAN, //42
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+        multicall: '0x2cc8688C5f75E365aaEEb4ea8D6a480405A48D2A',
+        subgraphUrl:
+            'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2',
+        staBal3Pool: {
+            id: '0x8fd162f338b770f7e879030830cde9173367f3010000000000000000000004d8',
+            address: '0x8fd162f338b770f7e879030830cde9173367f301',
+        },
+        wethStaBal3: {
+            id: '0x6be79a54f119dbf9e8ebd9ded8c5bd49205bc62d00020000000000000000033c',
+            address: '0x6be79a54f119dbf9e8ebd9ded8c5bd49205bc62d',
+        },
+    },
+    [Network.POLYGON]: {
+        chainId: Network.POLYGON, //137
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+        multicall: '0xa1B2b503959aedD81512C37e9dce48164ec6a94d',
+        subgraphUrl:
+            'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2',
+    },
+    [Network.ARBITRUM]: {
+        chainId: Network.ARBITRUM, //42161
+        vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+        weth: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+        multicall: '0x269ff446d9892c9e19082564df3f5e8741e190a1',
+        subgraphUrl:
+            'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2',
+    },
+};

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -1,6 +1,48 @@
 import { BigNumberish } from '@ethersproject/bignumber';
 import { Network } from './constants/network';
 import { Contract } from '@ethersproject/contracts';
+import { PoolDataService, TokenPriceService } from '@balancer-labs/sor';
+import { Provider } from '@ethersproject/providers';
+
+export interface BalancerSdkConfig {
+    //use a known network or provide an entirely custom config
+    network: Network | BalancerNetworkConfig;
+    rpcUrl: string;
+    //default to JsonRpcProvider if not provided
+    provider?: Provider;
+    //overwrite the subgraph url if you don't want to use the balancer labs maintained version
+    customSubgraphUrl?: string;
+    //optionally overwrite parts of the standard SOR config
+    sor?: Partial<BalancerSdkSorConfig>;
+}
+
+export interface BalancerSdkSorConfig {
+    //use a built-in service or provide a custom implementation of a TokenPriceService
+    //defaults to coingecko
+    tokenPriceService: 'coingecko' | 'subgraph' | TokenPriceService;
+    //use a built-in service or provide a custom implementation of a PoolDataService
+    //defaults to subgraph
+    poolDataService: 'subgraph' | PoolDataService;
+    //if a custom PoolDataService is provided, on chain balance fetching needs to be handled externally
+    //default to true.
+    fetchOnChainBalances: boolean;
+}
+
+export interface BalancerNetworkConfig {
+    chainId: Network;
+    vault: string;
+    weth: string;
+    multicall: string;
+    staBal3Pool?: {
+        id: string;
+        address: string;
+    };
+    wethStaBal3?: {
+        id: string;
+        address: string;
+    };
+    subgraphUrl: string;
+}
 
 export enum PoolSpecialization {
     GeneralPool = 0,
@@ -54,12 +96,6 @@ export type PoolBalanceOp = {
     poolId: string;
     token: string;
     amount: BigNumberish;
-};
-
-export type ConfigSdk = {
-    network: Network;
-    rpcUrl: string;
-    subgraphUrl: string;
 };
 
 export interface TransactionData {

--- a/balancer-js/yarn.lock
+++ b/balancer-js/yarn.lock
@@ -481,13 +481,13 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
-"@balancer-labs/sor@^2.1.0-beta.4":
-  version "2.1.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-2.1.0-beta.4.tgz#184b99861bf364f5348ba56a7bc9c971036e6e0e"
-  integrity sha512-q5W++wcMfF2MrVtlzK1XTWUgxQNqxTKOuWXMCpDpcpfHFe/n8UL9RMg8UMQl4dfFYUmThwqnXYad71ISyrRQNw==
+"@balancer-labs/sor@github:beethovenxfi/balancer-sor#daniel/sor-refactor-merged":
+  version "2.1.0-beta.3"
+  resolved "https://codeload.github.com/beethovenxfi/balancer-sor/tar.gz/9936bd8b9c178012d794afa7e55cfac359ad77bd"
   dependencies:
     "@georgeroman/balancer-v2-pools" "0.0.7"
     isomorphic-fetch "^2.2.1"
+    sdk-latest "npm:@georgeroman/balancer-v2-pools"
 
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"
@@ -4536,6 +4536,13 @@ scuid@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/scuid/-/scuid-1.1.0.tgz#d3f9f920956e737a60f72d0e4ad280bf324d5dab"
   integrity sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==
+
+"sdk-latest@npm:@georgeroman/balancer-v2-pools":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@georgeroman/balancer-v2-pools/-/balancer-v2-pools-0.0.14.tgz#53e32d126dd47b2f2a80aa47111fd0bceb7b1e58"
+  integrity sha512-/A8ENwtu1ts/rfSfr5wb1wRxMIu8s8cKew28C/qIVDxjhFT+mcpohEaNlEnstAdnuMlWaroJEu9jVJlCD7xE2Q==
+  dependencies:
+    bignumber.js "^9.0.1"
 
 semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
This PR builds upon https://github.com/balancer-labs/balancer-sdk/pull/20

The `BalancerSdkConfig` should serve as the basis for a global config object with the goal of providing both a simple way to create the SDK for standard usecases and the ability to customize and extend the SDK when necessary.

```
export interface BalancerSdkConfig {
    //use a known network or provide an entirely custom config
    network: Network | BalancerNetworkConfig;
    rpcUrl: string;
    //default to JsonRpcProvider if not provided
    provider?: Provider;
    //overwrite the subgraph url if you don't want to use the balancer labs maintained version
    customSubgraphUrl?: string;
    //optionally overwrite parts of the standard SOR config
    sor?: Partial<BalancerSdkSorConfig>;
}
```

For the standard usecase, you'll be able to create the SDK with only the network ID and an rpc url:
```
const balancerSdk = new BalancerSdk({ network, rpcUrl});
```

We leverage the flexibility of typescript types to allow for the definition of the `network` to be simply the chain id OR a fully defined network config.
```
export interface BalancerSdkConfig {
    ...
    //use a known network or provide an entirely custom config
    network: Network | BalancerNetworkConfig;
    ...
}

export enum Network {
    MAINNET = 1,
    ROPSTEN = 3,
    RINKEBY = 4,
    GÖRLI = 5,
    KOVAN = 42,
    POLYGON = 137,
    ARBITRUM = 42161
}

export interface BalancerNetworkConfig {
    chainId: Network;
    vault: string;
    weth: string;
    multicall: string;
    staBal3Pool?: {
        id: string;
        address: string;
    };
    wethStaBal3?: {
        id: string;
        address: string;
    };
    subgraphUrl: string;
}
```

We provide the option to selectively overwrite data sources for the SOR. This should extend out into other parts of the SDK where applicable. Default config that is customisable where it makes sense.
```
export interface BalancerSdkSorConfig {
    //use a built-in service or provide a custom implementation of a TokenPriceService
    //defaults to coingecko
    tokenPriceService: 'coingecko' | 'subgraph' | TokenPriceService;
    //use a built-in service or provide a custom implementation of a PoolDataService
    //defaults to subgraph
    poolDataService: 'subgraph' | PoolDataService;
    //if a custom PoolDataService is provided, on chain balance fetching needs to be handled externally
    //default to true.
    fetchOnChainBalances: boolean;
}
```

Additionally in this PR:

- Use the refactored SOR package, this will need to get transitioned over to balancer-labs once its available.
- Define per network configs for all known networks
