### PR TITLE
Refactor SDK and SwapsService to use new interfaces

### DIFF
--- a/balancer-js/src/index.ts
+++ b/balancer-js/src/index.ts
@@ -10,3 +10,17 @@ export * from './constants/network';
 export * from './constants/subgraph';
 export * from './sdk';
 export * from './relayerService/index';
+export {
+    SwapInfo,
+    SubgraphPoolBase,
+    SwapTypes,
+    SwapOptions,
+    PoolFilter,
+    SwapV2,
+    queryBatchSwapTokensIn,
+    queryBatchSwapTokensOut,
+    phantomStableBPTForTokensZeroPriceImpact,
+    stableBPTForTokensZeroPriceImpact,
+    weightedBPTForTokensZeroPriceImpact,
+    SOR,
+} from '@balancer-labs/sor';

--- a/balancer-js/src/sdk/index.ts
+++ b/balancer-js/src/sdk/index.ts
@@ -1,22 +1,66 @@
-import { ConfigSdk } from '../types';
-import { Network } from '../constants/network';
+import {
+    BalancerNetworkConfig,
+    BalancerSdkConfig,
+    BalancerSdkSorConfig,
+} from '../types';
 import { SwapsService } from '../swapsService';
 import { RelayerService } from '../relayerService';
+import { SOR } from '@balancer-labs/sor';
+import { SorFactory } from '../sor/sorFactory';
+import { BALANCER_NETWORK_CONFIG } from '../constants/contracts';
+import { JsonRpcProvider, Provider } from '@ethersproject/providers';
+import { createSubgraphClient, SubgraphClient } from '../subgraph/subgraph';
 
 export class BalancerSDK {
-    network: Network;
-    rpcUrl: string;
-    swaps: SwapsService;
-    relayer: RelayerService;
+    public readonly network: BalancerNetworkConfig;
+    public readonly rpcUrl: string;
+    public readonly swaps: SwapsService;
+    public readonly relayer: RelayerService;
+    public readonly sor: SOR;
+    public readonly provider: Provider;
+    public readonly subgraphClient: SubgraphClient;
 
-    constructor(config: ConfigSdk, swapService = SwapsService, relayerService = RelayerService) {
-        this.network = config.network;
+    constructor(config: BalancerSdkConfig) {
+        this.network = this.getNetworkConfig(config);
         this.rpcUrl = config.rpcUrl;
-        this.swaps = new swapService({
-            network: this.network,
-            rpcUrl: this.rpcUrl,
-            subgraphUrl: config.subgraphUrl
-        });
-        this.relayer = new relayerService(this.swaps, this.rpcUrl);
+        this.provider = config.provider ?? new JsonRpcProvider(this.rpcUrl);
+        this.subgraphClient = createSubgraphClient(this.network.subgraphUrl);
+
+        const sorConfig = this.getSorConfig(config);
+        this.sor = SorFactory.createSor(
+            this.network,
+            sorConfig,
+            this.provider,
+            this.subgraphClient
+        );
+
+        this.swaps = new SwapsService(this.network, this.sor, this.provider);
+        this.relayer = new RelayerService(this.swaps, this.rpcUrl);
+    }
+
+    private getNetworkConfig(config: BalancerSdkConfig): BalancerNetworkConfig {
+        if (typeof config.network === 'number') {
+            const networkConfig = BALANCER_NETWORK_CONFIG[config.network];
+
+            return {
+                ...networkConfig,
+                subgraphUrl:
+                    config.customSubgraphUrl ?? networkConfig.subgraphUrl,
+            };
+        }
+
+        return {
+            ...config.network,
+            subgraphUrl: config.customSubgraphUrl ?? config.network.subgraphUrl,
+        };
+    }
+
+    private getSorConfig(config: BalancerSdkConfig): BalancerSdkSorConfig {
+        return {
+            tokenPriceService: 'coingecko',
+            poolDataService: 'subgraph',
+            fetchOnChainBalances: true,
+            ...config.sor,
+        };
     }
 }

--- a/balancer-js/src/swapsService/index.ts
+++ b/balancer-js/src/swapsService/index.ts
@@ -1,10 +1,14 @@
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { Provider } from '@ethersproject/providers';
 import { Contract } from '@ethersproject/contracts';
-import { SOR, SubgraphPoolBase } from '@balancer-labs/sor';
+import { SOR } from '@balancer-labs/sor';
 
-import { ConfigSdk } from '../types';
-import { Network } from '../constants/network';
-import { SwapType, QueryWithSorInput, QueryWithSorOutput, BatchSwap } from './types';
+import { BalancerNetworkConfig } from '../types';
+import {
+    BatchSwap,
+    QueryWithSorInput,
+    QueryWithSorOutput,
+    SwapType,
+} from './types';
 import { queryBatchSwap, queryBatchSwapWithSor } from './queryBatchSwap';
 import { balancerVault } from '../constants/contracts';
 import { getLimitsForSlippage } from './helpers';
@@ -12,16 +16,11 @@ import { getLimitsForSlippage } from './helpers';
 import vaultAbi from '../abi/Vault.json';
 
 export class SwapsService {
-    network: Network;
-    rpcUrl: string;
-    sor: SOR;
-
-    constructor(config: ConfigSdk) {
-        this.network = config.network;
-        this.rpcUrl = config.rpcUrl;
-        const provider = new JsonRpcProvider(this.rpcUrl);
-        this.sor = new SOR(provider, this.network, config.subgraphUrl);
-    }
+    constructor(
+        private readonly network: BalancerNetworkConfig,
+        private readonly sor: SOR,
+        private readonly provider: Provider
+    ) {}
 
     static getLimitsForSlippage(
         tokensIn: string[],
@@ -41,7 +40,7 @@ export class SwapsService {
             slippage
         );
 
-        return limits.map(l => l.toString());
+        return limits.map((l) => l.toString());
     }
 
     /**
@@ -50,11 +49,8 @@ export class SwapsService {
      * @param {boolean} [isOnChain=true] If isOnChain is true will retrieve all required onChain data via multicall otherwise uses subgraph values.
      * @returns {boolean} Boolean indicating whether pools data was fetched correctly (true) or not (false).
      */
-    async fetchPools(
-        poolsData: SubgraphPoolBase[] = [],
-        isOnChain = true
-    ): Promise<boolean> {
-        return this.sor.fetchPools(poolsData, isOnChain);
+    async fetchPools(): Promise<boolean> {
+        return this.sor.fetchPools();
     }
 
     /**
@@ -71,8 +67,11 @@ export class SwapsService {
         batchSwap: Pick<BatchSwap, 'kind' | 'swaps' | 'assets'>
     ): Promise<string[]> {
         // TO DO - Pull in a ContractsService and use this to pass Vault to queryBatchSwap.
-        const provider = new JsonRpcProvider(this.rpcUrl);
-        const vaultContract = new Contract(balancerVault, vaultAbi, provider);
+        const vaultContract = new Contract(
+            balancerVault,
+            vaultAbi,
+            this.provider
+        );
 
         return await queryBatchSwap(
             vaultContract,
@@ -92,10 +91,15 @@ export class SwapsService {
      * @param {FetchPoolsInput} queryWithSor.fetchPools - Set whether SOR will fetch updated pool info.
      * @returns {Promise<QueryWithSorOutput>} Returns amount of tokens swaps along with swap and asset info that can be submitted to a batchSwap call.
      */
-    async queryBatchSwapWithSor(queryWithSor: QueryWithSorInput): Promise<QueryWithSorOutput> {
+    async queryBatchSwapWithSor(
+        queryWithSor: QueryWithSorInput
+    ): Promise<QueryWithSorOutput> {
         // TO DO - Pull in a ContractsService and use this to pass Vault to queryBatchSwap.
-        const provider = new JsonRpcProvider(this.rpcUrl);
-        const vaultContract = new Contract(balancerVault, vaultAbi, provider);
+        const vaultContract = new Contract(
+            balancerVault,
+            vaultAbi,
+            this.provider
+        );
 
         return await queryBatchSwapWithSor(
             this.sor,


### PR DESCRIPTION
This PR builds upon https://github.com/balancer-labs/balancer-sdk/pull/20, #1, #2 and #3.

- Refactored the `BalancerSdk` to support the `BalancerSdkConfig`
  - More precise access modifiers on variables/functions
  - If a network Id is provided, map to the full network config
  - Populate "default" values for `SorConfig`
  - Expose the SOR from the SDK.
- Refactored the `SwapsService` to support the `BalancerSdkConfig`
  - `SOR` is now passed in as a constructor param 
- Export the SOR explicitly in the index.ts so that all the types are available externally.